### PR TITLE
Fixing some false-positives

### DIFF
--- a/userrecon.sh
+++ b/userrecon.sh
@@ -503,7 +503,7 @@ fi
 ## Instructables
 
 printf "\e[1;77m[\e[0m\e[1;92m+\e[0m\e[1;77m] Instructables: \e[0m"
-check1=$(curl -s -i "https://www.instructables.com/member/$username" -H "Accept-Language: en" -L | grep -o '404 NOT FOUND' ; echo $?)
+check1=$(curl -s -i "https://www.instructables.com/member/$username" -H "Accept-Language: en" -L | grep -o '404 Not Found' ; echo $?)
 
 if [[ $check1 == *'0'* ]] ; then 
 printf "\e[1;93mNot Found!\e[0m\n"

--- a/userrecon.sh
+++ b/userrecon.sh
@@ -711,7 +711,7 @@ fi
 ## CreativeMarket
 
 printf "\e[1;77m[\e[0m\e[1;92m+\e[0m\e[1;77m] CreativeMarket: \e[0m"
-check1=$(curl -s -i "https://creativemarket.com/$username" -H "Accept-Language: en" -L | grep -o '404eef72' ; echo $?)
+check1=$(curl -s -i "https://creativemarket.com/$username" -H "Accept-Language: en" | grep -o 'location: https://creativemarket.com/' ; echo $?)
 
 if [[ $check1 == *'0'* ]] ; then 
 printf "\e[1;93mNot Found!\e[0m\n"

--- a/userrecon.sh
+++ b/userrecon.sh
@@ -802,7 +802,7 @@ fi
 ## Houzz
 
 printf "\e[1;77m[\e[0m\e[1;92m+\e[0m\e[1;77m] Houzz: \e[0m"
-check1=$(curl -s -i "https://houzz.com/user/$username" -H "Accept-Language: en" -L | grep -o 'an error has occurred' ; echo $?)
+check1=$(curl -s -i "https://houzz.com/user/$username" -H "Accept-Language: en" -L | grep -o 'The page you requested was not found' ; echo $?)
 
 if [[ $check1 == *'0'* ]] ; then 
 printf "\e[1;93mNot Found!\e[0m\n"

--- a/userrecon.sh
+++ b/userrecon.sh
@@ -320,11 +320,11 @@ fi
 ## FlipBoard
 
 printf "\e[1;77m[\e[0m\e[1;92m+\e[0m\e[1;77m] Flipboard: \e[0m"
-check1=$(curl -s -i "https://flipboard.com/@$username" -H "Accept-Language: en" -L | grep -o 'HTTP/2 404' ; echo $?)
+check1=$(curl -s -i "https://flipboard.com/@$username" -H "Accept-Language: en" -L | grep -o 'data-vars-button-name="profile-header-follow"' ; echo $?)
 
-if [[ $check1 == *'0'* ]] ; then 
+if [[ $check1 == *'1'* ]] ; then 
 printf "\e[1;93mNot Found!\e[0m\n"
-elif [[ $check1 == *'1'* ]]; then 
+elif [[ $check1 == *'0'* ]]; then 
 
 printf "\e[1;92m Found!\e[0m https://flipboard.com/@%s\n" $username
 printf "https://flipboard.com/@%s\n" $username >> $username.txt

--- a/userrecon.sh
+++ b/userrecon.sh
@@ -555,7 +555,7 @@ fi
 ## AngelList
 
 printf "\e[1;77m[\e[0m\e[1;92m+\e[0m\e[1;77m] AngelList: \e[0m"
-check1=$(curl -s -i "https://angel.co/$username" -H "Accept-Language: en" -L | grep -o '404 Not Found' ; echo $?)
+check1=$(curl -s -i "https://angel.co/$username" -H "Accept-Language: en" -L | grep -o 'Page not found - 404' ; echo $?)
 
 if [[ $check1 == *'0'* ]] ; then 
 printf "\e[1;93mNot Found!\e[0m\n"


### PR DESCRIPTION
Due to changes in some of the scanned websites, userrecon had begun to return some false-positives. I have gone through and fixed all the ones I could find. Most of the fixes are pretty self-explanatory, though two require some attention:

  1. Flipboard no longer returns a 404. Instead it seems to just hang. However, if a user is found, a "follow" button will always be present. Now instead of looking for 404, we look for the button.

2. CreativeMarket no longer returns a 404. Instead, if an invalid user is requested, it simply redirects to the home page. I modified the command to notice this redirect back to the home page.